### PR TITLE
Use concret parent to make plexus-digest buildable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-components</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0</version>
+    <relativePath/>
   </parent>
 
   <artifactId>plexus-digest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,15 @@
   <name>Plexus Digest / Hashcode Components</name>
 
   <scm>
-    <connection>scm:git:git@github.com:sonatype/plexus-digest.git</connection>
-    <developerConnection>scm:git:git@github.com:sonatype/plexus-digest.git</developerConnection>
+    <connection>scm:git:git@github.com:codehaus-plexus/plexus-digest.git</connection>
+    <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-digest.git</developerConnection>
+    <url>http://github.com/codehaus-plexus/plexus-digest</url>
+    <tag>HEAD</tag>
   </scm>
+  <issueManagement>
+    <system>github</system>
+    <url>http://github.com/codehaus-plexus/plexus-digest/issues</url>
+  </issueManagement>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus-components</artifactId>
-    <version>1.3.1</version>
+    <version>4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-digest</artifactId>
@@ -22,6 +22,12 @@
     <system>github</system>
     <url>http://github.com/codehaus-plexus/plexus-digest/issues</url>
   </issueManagement>
+  <distributionManagement>
+    <site>
+      <id>github:gh-pages</id>
+      <url>${project.scm.developerConnection}</url>
+    </site>
+  </distributionManagement>
 
   <dependencies>
     <dependency>
@@ -38,4 +44,25 @@
       <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <configuration>
+          <content>${project.reporting.outputDirectory}</content><!-- mono-module doesn't require site:stage -->
+        </configuration>
+        <executions>
+          <execution>
+            <id>scm-publish</id>
+            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
+            <goals>
+              <goal>publish-scm</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
   <name>Plexus Digest / Hashcode Components</name>
 
   <scm>
-    <connection>scn:git:git@github.com:sonatype/plexus-digest.git</connection>
-    <developerConnection>scn:git:git@github.com:sonatype/plexus-digest.git</developerConnection>
+    <connection>scm:git:git@github.com:sonatype/plexus-digest.git</connection>
+    <developerConnection>scm:git:git@github.com:sonatype/plexus-digest.git</developerConnection>
   </scm>
 
   <dependencies>


### PR DESCRIPTION
The current implementation points to plexus-components 4.0-SNAPSHOT, so it isn't buildable by independent developers like me.
This PR uses the already relased version 4.0 of plexus-components and sets the relativePath to nothing.
